### PR TITLE
Fixes #19.  Add destructor to ConditionBank.

### DIFF
--- a/junction/striped/ConditionBank.cpp
+++ b/junction/striped/ConditionBank.cpp
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------
   Junction: Concurrent data structures in C++
-  Copyright (c) 2016 Jeff Preshing
+  Copyright (c) 2016-2017 Jeff Preshing
 
   Distributed under the Simplified BSD License.
   Original location: https://github.com/preshing/junction
@@ -19,6 +19,13 @@ namespace junction {
 namespace striped {
 
 ConditionBank DefaultConditionBank;
+
+ConditionBank::~ConditionBank() {
+    m_initSpinLock.lock();
+    ConditionPair* pairs = m_pairs.exchange(nullptr, turf::ConsumeRelease);
+    delete [] pairs;
+    m_initSpinLock.unlock();
+}
 
 ConditionPair* ConditionBank::initialize() {
     m_initSpinLock.lock();

--- a/junction/striped/ConditionBank.h
+++ b/junction/striped/ConditionBank.h
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------
   Junction: Concurrent data structures in C++
-  Copyright (c) 2016 Jeff Preshing
+  Copyright (c) 2016-2017 Jeff Preshing
 
   Distributed under the Simplified BSD License.
   Original location: https://github.com/preshing/junction
@@ -36,6 +36,8 @@ private:
     ConditionPair* initialize();
 
 public:
+    ~ConditionBank();
+
     ConditionPair& get(void* ptr) {
         ConditionPair* pairs = m_pairs.load(turf::Consume);
         if (!pairs) {

--- a/samples/MallocTest/MallocTest.cpp
+++ b/samples/MallocTest/MallocTest.cpp
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------
   Junction: Concurrent data structures in C++
-  Copyright (c) 2016 Jeff Preshing
+  Copyright (c) 2016-2017 Jeff Preshing
 
   Distributed under the Simplified BSD License.
   Original location: https://github.com/preshing/junction
@@ -22,6 +22,8 @@ int main() {
     junction::extra::MapAdapter::ThreadContext context(adapter, 0);
     junction::extra::MapAdapter::Map map(65536);
 
+    context.registerThread();
+
     ureg population = 0;
     for (ureg i = 0; i < 100; i++) {
 #if TURF_USE_DLMALLOC && TURF_DLMALLOC_FAST_STATS
@@ -30,6 +32,9 @@ int main() {
         for (; population < i * 5000; population++)
             map.assign(population + 1, (void*) ((population << 2) | 3));
     }
+
+    context.update();
+    context.unregisterThread();
 
     return 0;
 }


### PR DESCRIPTION
Added a destructor to the ConditionBank class to deallocate the m_pair array.
Valgrind was used to test the shutdown of samples/MallocTest was clean.

Additional changes were needed in MallocTest to register with and update QSBR
so the table migration would be cleaned up.